### PR TITLE
Moved ForgeGradle gradle classpath to subprojects.

### DIFF
--- a/1.7.10/build.gradle
+++ b/1.7.10/build.gradle
@@ -2,6 +2,11 @@ apply plugin: 'forge'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'maven-publish'
 
+buildscript {
+	dependencies {
+		classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+	}
+}
 
 dependencies {
 	if (project.hasProperty("nova.core.location")) {

--- a/1.8/build.gradle
+++ b/1.8/build.gradle
@@ -2,6 +2,11 @@ apply plugin: 'forge'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'maven-publish'
 
+buildscript {
+	dependencies {
+		classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+	}
+}
 
 dependencies {
 	if (project.hasProperty("nova.core.location")) {

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ subprojects {
 	// Add plugins to classpath on every subproject
 	buildscript {
 		dependencies {
-			classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
 			classpath 'us.phildop:gradle-sublimetext-plugin:0.5.3'
 			classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
 		}


### PR DESCRIPTION
This is because we cannot assume that every minecraft version is using
exactly the same ForgeGradle version.